### PR TITLE
fix(utils): correctly type `fromMachine`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ Adds undo/redo functionality to a given `Behavior`.
 
 ### `fromMachine`
 
-> (!) This utility currently has some TypeScript problems. See the relevant
-> [issue](https://github.com/christoph-fricke/xsystem/issues/1) for more
-> information.
-
 Creates a `Behavior` from a given machine that is created with `createMachine`
 or `model.createMachine`.
 

--- a/src/utils/from_machine.test.ts
+++ b/src/utils/from_machine.test.ts
@@ -18,15 +18,12 @@ function createPingMachine() {
 
 describe(fromMachine, () => {
 	it("should create a behavior from a machine definition", () => {
-		//@ts-expect-error Typings currently do not work correctly
 		const behavior = fromMachine(createPingMachine());
 		const actor = spawnBehavior(behavior);
 
 		// Test that the spawned behavior works as expected
 		expect(actor.getSnapshot()?.value).toBe("ping");
-
 		actor.send({ type: "ping" });
-
 		expect(actor.getSnapshot()?.value).toBe("pong");
 	});
 });

--- a/src/utils/from_machine.ts
+++ b/src/utils/from_machine.ts
@@ -1,30 +1,29 @@
 import {
+	AnyInterpreter,
 	Behavior,
 	EventObject,
+	interpret,
+	Interpreter,
 	State,
 	StateMachine,
+	StateSchema,
 	Typestate,
-	interpret,
-	AnyInterpreter,
 } from "xstate";
 
 /**
  * Creates a {@link Behavior} from a given machine. This makes the machine
  * composable with higher order behavior, e.g. `withPubSub`.
- *
- * TODO: This function has major TS problems. I don't know why. I can't assign a created machine.
  */
 export function fromMachine<
-	M extends StateMachine<C, S, E, TS>,
 	C,
-	S,
+	S extends StateSchema<unknown>,
 	E extends EventObject,
 	TS extends Typestate<C>
 >(
-	machine: M,
+	machine: StateMachine<C, S, E, TS>,
 	options?: Parameters<typeof interpret>["1"]
 ): Behavior<E, State<C, E, S, TS>> {
-	let service: AnyInterpreter | undefined;
+	let service: Interpreter<C, S, E, TS> | undefined;
 
 	// TODO: Stop machines once https://github.com/statelyai/xstate/pull/2560 is merged
 


### PR DESCRIPTION
This PR fixes #1 with a solution that has been provided by Matt Pocock: https://discord.com/channels/795785288994652170/809564589880639548/893596128069709824