### PR TITLE
Simplify Typings for Subscribe Events

### DIFF
--- a/src/messaging/pub_sub.ts
+++ b/src/messaging/pub_sub.ts
@@ -1,9 +1,4 @@
-import type {
-	ActionObject,
-	AnyEventObject,
-	Behavior,
-	EventObject,
-} from "xstate";
+import type { ActionObject, Behavior, EventObject } from "xstate";
 import type { SubEvent, Publish } from "../subscriptions/mod";
 import {
 	createSubscriberStructure,
@@ -16,7 +11,7 @@ export type WithPubSub<P extends EventObject, B> = B extends Behavior<
 	infer E,
 	infer S
 >
-	? Behavior<E | SubEvent<P, AnyEventObject>, S>
+	? Behavior<E | SubEvent<P>, S>
 	: never;
 
 /**

--- a/src/subscriptions/events.test.ts
+++ b/src/subscriptions/events.test.ts
@@ -1,3 +1,4 @@
+import type { ActorRef } from "xstate";
 import { subscribe, unsubscribe } from "./events";
 
 describe(subscribe, () => {
@@ -9,7 +10,7 @@ describe(subscribe, () => {
 		expect(event).toMatchObject({
 			type: "xsystem.subscribe",
 			ref: baseActor,
-			events: ["*"],
+			matches: ["*"],
 		});
 	});
 
@@ -21,8 +22,19 @@ describe(subscribe, () => {
 		expect(event).toMatchObject({
 			type: "xsystem.subscribe",
 			ref: baseActor,
-			events: ["test_event", "event"],
+			matches: ["test_event", "event"],
 		});
+	});
+
+	it("should be possible to provide an actor ref as the reference", () => {
+		// Previously, a bug existed where it was not possible to pass an actor ref
+		// with an typed event generic. The typing should not care about the receive-able
+		// event of the reference as it can never be fully typed down the line and always
+		// led to problems and complexity without user benefits.
+		const actor = {} as ActorRef<{ type: "test" }, null>;
+
+		// Test is considered passing when this expression does not produce a type error
+		subscribe<{ type: "publish" }>(actor);
 	});
 });
 
@@ -36,5 +48,16 @@ describe(unsubscribe, () => {
 			type: "xsystem.unsubscribe",
 			ref: baseActor,
 		});
+	});
+
+	it("should be possible to provide an actor ref as the reference", () => {
+		// Previously, a bug existed where it was not possible to pass an actor ref
+		// with an typed event generic. The typing should not care about the receive-able
+		// event of the reference as it can never be fully typed down the line and always
+		// led to problems and complexity without user benefits.
+		const actor = {} as ActorRef<{ type: "test" }, null>;
+
+		// Test is considered passing when this expression does not produce a type error
+		unsubscribe(actor);
 	});
 });

--- a/src/subscriptions/events.ts
+++ b/src/subscriptions/events.ts
@@ -6,49 +6,36 @@ export type EventMatch<E extends EventObject> =
 	| E["type"]
 	| Wildcard<E["type"], ".">;
 
-export type SubEvent<SEvent extends EventObject, AEvent extends EventObject> =
-	| SubscribeEvent<SEvent, AEvent>
-	| UnsubscribeEvent<SEvent, AEvent>;
+/** Either a {@link SubscribeEvent} or {@link UnsubscribeEvent}. */
+export type SubEvent<E extends EventObject> =
+	| SubscribeEvent<E>
+	| UnsubscribeEvent;
 
-export interface SubscribeEvent<
-	SEvent extends EventObject,
-	AEvent extends EventObject
-> extends EventObject {
+export interface SubscribeEvent<E extends EventObject> extends EventObject {
 	type: "xsystem.subscribe";
-	ref: BaseActorRef<SEvent | AEvent>;
-	events: EventMatch<SEvent>[];
+	ref: BaseActorRef<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+	matches: EventMatch<E>[];
 }
 
 /** Returns an {@link SubscribeEvent}. */
-export function subscribe<
-	SEvent extends EventObject,
-	AEvent extends EventObject
->(
-	ref: SubscribeEvent<SEvent, AEvent>["ref"],
-	events?: SubscribeEvent<SEvent, AEvent>["events"]
-): SubscribeEvent<SEvent, AEvent> {
+export function subscribe<E extends EventObject>(
+	ref: SubscribeEvent<E>["ref"],
+	matches?: SubscribeEvent<E>["matches"]
+): SubscribeEvent<E> {
 	return {
 		type: "xsystem.subscribe",
 		ref,
-		events: events ?? ["*"],
+		matches: matches ?? ["*"],
 	};
 }
 
-export interface UnsubscribeEvent<
-	SEvent extends EventObject,
-	AEvent extends EventObject
-> extends EventObject {
+export interface UnsubscribeEvent extends EventObject {
 	type: "xsystem.unsubscribe";
-	ref: BaseActorRef<SEvent | AEvent>;
+	ref: BaseActorRef<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 /** Returns an {@link UnsubscribeEvent}. */
-export function unsubscribe<
-	SEvent extends EventObject,
-	AEvent extends EventObject
->(
-	ref: UnsubscribeEvent<SEvent, AEvent>["ref"]
-): UnsubscribeEvent<SEvent, AEvent> {
+export function unsubscribe(ref: UnsubscribeEvent["ref"]): UnsubscribeEvent {
 	return {
 		type: "xsystem.unsubscribe",
 		ref,

--- a/src/subscriptions/subscribers.ts
+++ b/src/subscriptions/subscribers.ts
@@ -12,7 +12,7 @@ import { getAllWildcards } from "./wildcard";
 
 type SubscriberMap<E extends EventObject> = BucketMap<
 	EventMatch<E>,
-	BaseActorRef<E | AnyEventObject>
+	BaseActorRef<AnyEventObject>
 >;
 
 /**
@@ -30,14 +30,14 @@ export function createSubscriberStructure<
 export function handleSubscribeEvent<E extends EventObject>(
 	subscribers: SubscriberMap<E>,
 	event: AnyEventObject
-): event is SubEvent<E, AnyEventObject> {
-	if (is<SubscribeEvent<E, AnyEventObject>>("xsystem.subscribe", event)) {
-		for (const type of event.events) subscribers.add(type, event.ref);
+): event is SubEvent<E> {
+	if (is<SubscribeEvent<E>>("xsystem.subscribe", event)) {
+		for (const type of event.matches) subscribers.add(type, event.ref);
 
 		return true;
 	}
 
-	if (is<UnsubscribeEvent<E, AnyEventObject>>("xsystem.unsubscribe", event)) {
+	if (is<UnsubscribeEvent>("xsystem.unsubscribe", event)) {
 		subscribers.delete(event.ref);
 
 		return true;

--- a/src/utils/from_actor.ts
+++ b/src/utils/from_actor.ts
@@ -1,31 +1,29 @@
 import { ActorRef, AnyEventObject, EventObject, InvokeCreator } from "xstate";
 import type { EventMatch, SubEvent } from "../subscriptions/events";
 import { subscribe, unsubscribe } from "../subscriptions/events";
-import { BaseActorRef } from "./types";
 
 type SubscribeAble<
-	SEvent extends EventObject,
-	AEvent extends EventObject,
+	P extends EventObject,
 	Actor = ActorRef<AnyEventObject>
 > = Actor extends ActorRef<infer E, infer S>
-	? ActorRef<E | SubEvent<SEvent, AEvent>, S>
+	? ActorRef<E | SubEvent<P>, S>
 	: never;
 
 /** Creates an invoke callback that subscribes to the events published by a given actor. */
 export function fromActor<TContext, TEvent extends EventObject>(
-	getActor: (ctx: TContext, e: TEvent) => SubscribeAble<TEvent, TEvent>,
-	events?: EventMatch<TEvent>[]
+	getActor: (ctx: TContext, e: TEvent) => SubscribeAble<TEvent>,
+	matches?: EventMatch<TEvent>[]
 ): InvokeCreator<TContext, TEvent> {
 	return (ctx, e) => (send, onReceive) => {
 		const actor = getActor(ctx, e);
-		const thisActorBase: BaseActorRef<TEvent> = { send };
+		const thisBaseActor = { send };
 
-		actor.send(subscribe(thisActorBase, events));
+		actor.send(subscribe(thisBaseActor, matches));
 
 		onReceive((e) => actor.send(e));
 
 		return () => {
-			actor.send(unsubscribe(thisActorBase));
+			actor.send(unsubscribe(thisBaseActor));
 		};
 	};
 }


### PR DESCRIPTION
The previous subscribe events tried to fully model the events that can be received by the provided reference. This caused type problems further down the line when `subscribe` is actually used to subscribe to subscribe-able actors. Furthermore, the full typed model was already replaced with `AnyEventObject` by higher subscription mechanisms since they were unable to fully predict the event type for all handled subscribers.

To avoid the previous problems and unnecessary complexity, the event that can be received by the reference are now modeled as `any`.