### PR TITLE
HOB: withSubscription

### DIFF
--- a/src/behaviors/mod.ts
+++ b/src/behaviors/mod.ts
@@ -1,1 +1,2 @@
 export * from "./history";
+export * from "./with_subscription";

--- a/src/behaviors/with_subscription.test.ts
+++ b/src/behaviors/with_subscription.test.ts
@@ -1,0 +1,34 @@
+import { mock } from "jest-mock-extended";
+import type { ActorRef, AnyEventObject, Behavior } from "xstate";
+import { spawnBehavior } from "xstate/lib/behaviors";
+import { subscribe, SubEvent } from "../subscriptions/mod";
+import { withSubscription } from "./with_subscription";
+
+type AnyBehavior = Behavior<AnyEventObject, unknown>;
+type AnyActor = ActorRef<SubEvent<AnyEventObject>, unknown>;
+
+describe(withSubscription, () => {
+	it("should subscribe a behavior to a publisher when spawned", () => {
+		const behavior = mock<AnyBehavior>();
+		const publisher = mock<AnyActor>();
+
+		const wrapped = withSubscription(behavior, publisher);
+		const actor = spawnBehavior(wrapped);
+
+		expect(publisher.send).toBeCalledTimes(1);
+		expect(publisher.send).toBeCalledWith(subscribe(actor));
+	});
+
+	it.todo("should unsubscribe a subscribed behavior when stopped");
+
+	it("should infer typings without explicit usage of generics", () => {
+		type BehaviorEvent = { type: "test" };
+		type PubEvent = { type: "hello" };
+
+		const behavior = mock<Behavior<BehaviorEvent, string>>();
+		const publisher = mock<ActorRef<SubEvent<PubEvent>, number>>();
+
+		// @ts-expect-error "foo" is not an published event
+		withSubscription(behavior, publisher, ["foo"]);
+	});
+});

--- a/src/behaviors/with_subscription.ts
+++ b/src/behaviors/with_subscription.ts
@@ -1,0 +1,32 @@
+import type { ActorRef, Behavior, EventObject } from "xstate";
+import type { SubEvent, EventMatch } from "../subscriptions/mod";
+import { subscribe } from "../subscriptions/mod";
+
+/**
+ * HOB that subscribes an actor that is spawned from the given `behavior` to an
+ * provided `publisher`. As expected from the pub/sub pattern in _XSystem_,
+ * an optional {@link EventMatch}es can be provided to only subscribe
+ * to certain events.
+ *
+ * In the future, spawned actors will be unsubscribed automatically when the
+ * required support drops in _XState_.
+ */
+export function withSubscription<
+	E extends EventObject,
+	S,
+	P extends EventObject
+>(
+	behavior: Behavior<E, S>,
+	publisher: ActorRef<SubEvent<P>, unknown>,
+	matches?: EventMatch<P>[]
+): Behavior<E, S> {
+	// TODO: Unsubscribe behavior when "stop" behavior support is added in XState.
+
+	return {
+		...behavior,
+		start: (ctx) => {
+			publisher.send(subscribe(ctx.self, matches));
+			return behavior.start?.(ctx) ?? behavior.initialState;
+		},
+	};
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-export { withHistory, undo, redo } from "./behaviors/mod";
+export { withSubscription, withHistory, undo, redo } from "./behaviors/mod";
 export type { WithHistory } from "./behaviors/mod";
 
 export {


### PR DESCRIPTION
Makes it less verbose to subscribe an actor that is spawned from a behavior to a publisher.
The subscription is handled automatically by the life-cycle of the behavior.

Instead of manually subscribing and unsubscribing the spawned actor, its behavior can simply be wrapped in `withSubscription`.

```typescript
const behavior: Behavior/* ... */;
const publisher: ActorRef/* ... */;

const wrapped = withSubscription(behavior, publisher, ["publish-matches"]);
const actor = spawnBehavior(wrapped);
```