### PR TITLE
Event-Bus: Add optional BroadcastChannel polyfill factory

### DIFF
--- a/src/messaging/event_bus.test.ts
+++ b/src/messaging/event_bus.test.ts
@@ -74,6 +74,74 @@ describe(createEventBus, () => {
 		expect(subscriber.send).toBeCalledWith(event1);
 		expect(subscriber.send).not.toBeCalledWith(event2);
 	});
+
+	describe("broadcast strategy", () => {
+		it("should accept an provided broadcast channel", () => {
+			const channel = mock<BroadcastChannel>();
+			const factory = jest.fn().mockReturnValue(channel);
+
+			spawnBehavior(
+				createEventBus<BasicEvent>({ strategy: "broadcast", channel: factory }),
+				{ id: "test-id" }
+			);
+
+			expect(factory).toBeCalledTimes(1);
+			expect(factory).toBeCalledWith("test-id");
+		});
+
+		it("should call the provided broadcast channel with events", () => {
+			const channel = mock<BroadcastChannel>();
+			const event: BasicEvent = { type: "basic.first" };
+
+			const bus = spawnBehavior(
+				createEventBus<BasicEvent>({
+					strategy: "broadcast",
+					channel: () => channel,
+				})
+			);
+			bus.send(event);
+
+			expect(channel.postMessage).toBeCalledTimes(1);
+			expect(channel.postMessage).toBeCalledWith({
+				contextId: expect.any(Number),
+				event: event,
+			});
+		});
+	});
+
+	describe("global-broadcast strategy", () => {
+		it("should accept an provided broadcast channel", () => {
+			const channel = mock<BroadcastChannel>();
+			const factory = jest.fn().mockReturnValue(channel);
+
+			spawnBehavior(
+				createEventBus<BasicEvent>({
+					strategy: "global-broadcast",
+					channel: factory,
+				}),
+				{ id: "test-id" }
+			);
+
+			expect(factory).toBeCalledTimes(1);
+			expect(factory).toBeCalledWith("test-id");
+		});
+
+		it("should call the provided broadcast channel with messages", () => {
+			const channel = mock<BroadcastChannel>();
+			const event: BasicEvent = { type: "basic.first" };
+
+			const bus = spawnBehavior(
+				createEventBus<BasicEvent>({
+					strategy: "global-broadcast",
+					channel: () => channel,
+				})
+			);
+			bus.send(event);
+
+			expect(channel.postMessage).toBeCalledTimes(1);
+			expect(channel.postMessage).toBeCalledWith(event);
+		});
+	});
 });
 
 describe("EventBus interface", () => {

--- a/src/messaging/event_bus.ts
+++ b/src/messaging/event_bus.ts
@@ -22,13 +22,13 @@ interface CreateOptions {
 	 */
 	strategy: "direct" | "global-broadcast" | "broadcast";
 	/**
-	 * "Bring your own polyfill!" Optional factory function that will used by the
+	 * "Bring your own polyfill!" Optional factory function that is used by the
 	 * **global-broadcast** and **broadcast** strategy to access a {@link BroadcastChannel}.
 	 * The provided `id` should be used as a channel name.
 	 *
 	 * If no factory function is provided, the native API will be used when available.
 	 * If not available, it falls back to an no-op implementation of {@link BroadcastChannel},
-	 * which will continue to deliver messages in the same browser context.
+	 * which will continue to deliver events in the same browser context.
 	 */
 	channel: ChannelFactory;
 }

--- a/src/messaging/event_bus.ts
+++ b/src/messaging/event_bus.ts
@@ -22,7 +22,7 @@ interface CreateOptions {
 	 */
 	strategy: "direct" | "global-broadcast" | "broadcast";
 	/**
-	 * "Bring your own polyfill!" Optional factory function that is used by the
+	 * _"Bring your own polyfill!"_ Optional factory function that is used by the
 	 * **global-broadcast** and **broadcast** strategy to access a {@link BroadcastChannel}.
 	 * The provided `id` should be used as a channel name.
 	 *
@@ -85,7 +85,7 @@ function globalBroadcastBusBehavior<E extends EventObject>(
 			return state;
 		},
 		start(ctx) {
-			bcChannel = channel ? channel(ctx.id) : createBroadcastChannel(ctx.id);
+			bcChannel = channel?.(ctx.id) ?? createBroadcastChannel(ctx.id);
 			bcChannel.onmessage = (msg) => publish(msg.data);
 			bcChannel.onmessageerror = (msg) =>
 				ctx.observers.forEach((obs) => obs.error(msg));
@@ -118,7 +118,7 @@ function broadcastBusBehavior<E extends EventObject>(
 			return state;
 		},
 		start(ctx) {
-			bcChannel = channel ? channel(ctx.id) : createBroadcastChannel(ctx.id);
+			bcChannel = channel?.(ctx.id) ?? createBroadcastChannel(ctx.id);
 			bcChannel.onmessage = (msg) =>
 				msg.data.contextId === contextId ? publish(msg.data.event) : void 0;
 			bcChannel.onmessageerror = (msg) =>


### PR DESCRIPTION
Bring your own polyfill! Adds an optional factory function to the event-bus options, which is used by the
**global-broadcast** and **broadcast** strategy to access a `BroadcastChannel`.
The provided `id` should be used as a channel name.

If no factory function is provided, the native API will be used when available.
If not available, it falls back to an no-op implementation of `BroadcastChannel`,
which will continue to deliver messages in the same browser context.