### PR TITLE
feat(utils): add `event-creator` function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,4 +12,5 @@ export type { EventBus, WithPubSub } from "./messaging/mod";
 export { subscribe, unsubscribe } from "./subscriptions/mod";
 export type { Publish, SubEvent } from "./subscriptions/mod";
 
-export { fromActor, fromMachine, is } from "./utils/mod";
+export { fromActor, fromMachine, is, createEvent } from "./utils/mod";
+export type { EventFrom } from "./utils/mod";

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -25,7 +25,6 @@ describe(createEvent, () => {
 	it("should attach an `match` function to match events to the created event", () => {
 		const test = createEvent("test.event");
 
-		expect(typeof test.match).toBe("function");
 		expect(test.match({ type: "test.event" })).toBe(true);
 		expect(test.match({ type: "hello", num: 42 })).toBe(false);
 	});
@@ -36,6 +35,22 @@ describe(createEvent, () => {
 		const ev = test("123");
 
 		expect(ev).toStrictEqual({ type: "test.event", id: "123" });
+	});
+
+	it.only("should display and throw an type error if the prepare callback does not return object", () => {
+		// @ts-expect-error Must return something
+		const noReturn = createEvent("test", (id: string) => {
+			id;
+		});
+		// @ts-expect-error Must return an object
+		const noObject = createEvent("test", (id: string) => id);
+
+		expect(() => noReturn("123")).toThrowError(
+			new TypeError("Prepare must return an object. Was: undefined")
+		);
+		expect(() => noObject("123")).toThrowError(
+			new TypeError("Prepare must return an object. Was: 123")
+		);
 	});
 
 	it("should be possible to use created events in machine definitions", () => {

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -1,6 +1,5 @@
 import { createMachine, interpret } from "xstate";
-import { createModel } from "xstate/lib/model";
-import { createEvent, EventFrom, fromEventCreators } from "./event_creator";
+import { createEvent, EventFrom } from "./event_creator";
 
 describe(createEvent, () => {
 	it("should return an event-creator function", () => {
@@ -89,44 +88,5 @@ describe("EventFrom", () => {
 		};
 
 		expect(e).toBe(e);
-	});
-});
-
-describe(fromEventCreators, () => {
-	it("should aggregate event creators into an events object", () => {
-		const first = createEvent("test.first", (id: string) => ({ id }));
-		const second = createEvent("test.second");
-
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		const object = fromEventCreators(first, second);
-
-		expect(object).toStrictEqual({
-			"test.first": first,
-			"test.second": second,
-		});
-	});
-
-	it("should make it easier to attach event creators to models", () => {
-		const first = createEvent("test.first", (id: string) => ({ id }));
-		const second = createEvent("test.second");
-
-		const model = createModel(null, {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			events: fromEventCreators(first, second),
-		});
-
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(model.events["test.first"]("123")).toStrictEqual({
-			type: "test.first",
-			id: "123",
-		});
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(model.events["test.second"]()).toStrictEqual({
-			type: "test.second",
-		});
 	});
 });

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -31,20 +31,11 @@ describe(createEvent, () => {
 	});
 
 	it("should accept an payload creator as an optional argument", () => {
-		const test = createEvent("test.event", (id: string) => id);
+		const test = createEvent("test.event", (id: string) => ({ id }));
 
 		const ev = test("123");
 
-		expect(ev).toStrictEqual({ type: "test.event", payload: "123" });
-	});
-
-	it("should throw an error if the prepare callback returns no value", () => {
-		const call = () =>
-			createEvent("test", (id) => {
-				id;
-			});
-
-		expect(call()).toThrowError("prepareEvent did not return a value");
+		expect(ev).toStrictEqual({ type: "test.event", id: "123" });
 	});
 
 	it("should be possible to use created events in machine definitions", () => {
@@ -78,9 +69,7 @@ describe("EventFrom", () => {
 		// This assignment should not error.
 		const e: Ev = {
 			type: "test.event",
-			payload: {
-				id: "123",
-			},
+			id: "123",
 		};
 
 		expect(e).toBe(e);

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -37,7 +37,7 @@ describe(createEvent, () => {
 		expect(ev).toStrictEqual({ type: "test.event", id: "123" });
 	});
 
-	it.only("should display and throw an type error if the prepare callback does not return object", () => {
+	it("should display and throw an type error if the prepare callback does not return object", () => {
 		// @ts-expect-error Must return something
 		const noReturn = createEvent("test", (id: string) => {
 			id;

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -1,5 +1,6 @@
 import { createMachine, interpret } from "xstate";
-import { createEvent, EventFrom } from "./event_creator";
+import { createModel } from "xstate/lib/model";
+import { createEvent, EventFrom, fromEventCreators } from "./event_creator";
 
 describe(createEvent, () => {
 	it("should return an event-creator function", () => {
@@ -88,5 +89,44 @@ describe("EventFrom", () => {
 		};
 
 		expect(e).toBe(e);
+	});
+});
+
+describe(fromEventCreators, () => {
+	it("should aggregate event creators into an events object", () => {
+		const first = createEvent("test.first", (id: string) => ({ id }));
+		const second = createEvent("test.second");
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const object = fromEventCreators(first, second);
+
+		expect(object).toStrictEqual({
+			"test.first": first,
+			"test.second": second,
+		});
+	});
+
+	it("should make it easier to attach event creators to models", () => {
+		const first = createEvent("test.first", (id: string) => ({ id }));
+		const second = createEvent("test.second");
+
+		const model = createModel(null, {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			events: fromEventCreators(first, second),
+		});
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		expect(model.events["test.first"]("123")).toStrictEqual({
+			type: "test.first",
+			id: "123",
+		});
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		expect(model.events["test.second"]()).toStrictEqual({
+			type: "test.second",
+		});
 	});
 });

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -1,0 +1,117 @@
+import type { AnyEventObject, EventFrom as OriginalEventFrom } from "xstate";
+
+// This implementation is a port of `createAction` from Redux Toolkit, adapted
+// and simplified to fit into the XState ecosystem.
+// Original: https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/createAction.ts
+
+type UnknownFunction = (...args: unknown[]) => unknown;
+
+/**
+ * Extracts an event shape from provided type. If the provided type is not an event
+ * creator, the resolution is deferred to the original XState implementation
+ * of `EventFrom`.
+ */
+export type EventFrom<C> = C extends BaseEventCreator<infer T, infer P>
+	? StructuredEvent<T, P>
+	: OriginalEventFrom<C>;
+
+/**
+ * An event with an associated payload. This is the
+ * type of events returned by `createEvent()` event creators.
+ */
+export type StructuredEvent<T extends string = string, P = void> = {
+	type: T;
+	payload: P;
+};
+
+/** A "prepare" method to be used as the second parameter of {@link createEvent}. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PrepareEvent<P> = (...args: any[]) => P;
+
+/**
+ * Intermediate step to infer the payload and arguments from prepareEvent.
+ * @internal
+ */
+type _EventCreatorWithPayload<
+	T extends string,
+	PA extends PrepareEvent<unknown>
+> = PA extends PrepareEvent<infer P>
+	? EventCreatorWithPayload<T, Parameters<PA>, P>
+	: never;
+
+/** Basic type for all action creators. */
+interface BaseEventCreator<T extends string, P> {
+	type: T;
+	match: (action: AnyEventObject) => action is StructuredEvent<T, P>;
+}
+
+/**
+ * An event creator that takes multiple arguments which are passed
+ * to a `PrepareEvent` method to create the final event.
+ */
+export interface EventCreatorWithPayload<
+	T extends string,
+	Args extends unknown[],
+	P
+> extends BaseEventCreator<T, P> {
+	/** Calling this event creator with `Args` will return an event event object for the type. */
+	(...args: Args): StructuredEvent<T, P>;
+}
+
+/** An event creator of type `T` that takes no payload. */
+export interface EventCreatorNoPayload<T extends string>
+	extends BaseEventCreator<T, void> {
+	/** Calling this {@link EventCreator} will return a new event object with the defined type. */
+	(): StructuredEvent<T>;
+}
+
+/**
+ * A utility function to create an event creator for the given event type.
+ * An additional `type` property is attached to the event creator
+ * function which equals the provided type and can be referenced in machine
+ * definition to avoid duplicate event types and to simplify refactoring.
+ *
+ * Furthermore, a `match` method is attached to the event creator to serve as
+ * a type predicate, which narrows given events to events with the same type as
+ * events from the created event creator.
+ *
+ * Lastly, the event creator function will have its `toString()` method overridden
+ * so that it returns the event type.
+ *
+ * @param type The action type to use for created actions.
+ * @param prepare A method that takes any number of arguments and returns the event payload.
+ */
+export function createEvent<T extends string>(
+	type: T
+): EventCreatorNoPayload<T>;
+
+export function createEvent<T extends string, PE extends PrepareEvent<unknown>>(
+	type: T,
+	prepareEvent: PE
+): _EventCreatorWithPayload<T, PE>;
+
+export function createEvent(
+	type: string,
+	prepareEvent?: UnknownFunction
+): unknown {
+	function eventCreator(...args: unknown[]) {
+		if (!prepareEvent) return { type };
+
+		const payload = prepareEvent(...args);
+		if (!payload) {
+			throw new Error("prepareEvent did not return a value");
+		}
+
+		return {
+			type,
+			payload,
+		};
+	}
+
+	eventCreator.toString = () => `${type}`;
+	eventCreator.type = type;
+	eventCreator.match = (e: AnyEventObject): e is StructuredEvent =>
+		e.type === type;
+
+	return eventCreator;
+}

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -5,7 +5,7 @@ import type { AnyEventObject, EventFrom as OriginalEventFrom } from "xstate";
 // Original: https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/createAction.ts
 
 type Empty = Record<string, never>;
-export type Compute<A> = { [K in keyof A]: A[K] } & unknown;
+type Compute<A> = { [K in keyof A]: A[K] } & unknown;
 
 /**
  * Extracts an event shape from provided generic. If the provided generic is not an event
@@ -33,10 +33,9 @@ export type EventFrom<C> = C extends EventCreator<
  * An event with an optional payload. This is the
  * type of events returned by {@link createEvent} event creators.
  */
-export type CreatedEvent<
-	T extends string,
-	P extends object = Empty
-> = P extends Empty ? { type: T } : Compute<{ type: T } & P>;
+type CreatedEvent<T extends string, P extends object = Empty> = P extends Empty
+	? { type: T }
+	: Compute<{ type: T } & P>;
 
 /** A factory for constructing events that is created by {@link createEvent}. */
 interface EventCreator<
@@ -108,23 +107,33 @@ export function createEvent<
 	return eventCreator;
 }
 
-/**
- * Maps event creators to an event object for XState models.
- * TODO: Fix typings so it is correctly typed in usage. Currently, it throws errors.
- */
-export function fromEventCreators<
-	Creators extends EventCreator<T, P, A>[],
-	T extends string,
-	P extends object = Empty,
-	A extends unknown[] = []
->(...creators: Creators) {
-	const map: { [K in T]: EventCreator<K, P, A> } = {} as {
-		[K in T]: EventCreator<K, P, A>;
-	};
+// TODO: This is an idea to map event-creators into event object for XState models.
+// However, it does not work yet...
 
-	for (const creator of creators) {
-		map[creator.type] = creator;
-	}
+// /** Maps event creators to an event object for XState models. */
+// export function fromEventCreators<
+// 	Creators extends EventCreator<T, P, A>[],
+// 	T extends string,
+// 	P extends object,
+// 	A extends any[]
+// >(...creators: Creators): EventMap<Creators> {
+// 	const map = {} as EventMap<Creators>;
+//
+// 	for (const creator of creators) {
+// 		const prepare = (...args: A): P => {
+// 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// 			const {type, ...payload} = creator(...args);
+// 			return payload as P;
+// 		}
+// 		map[creator.type] = prepare;
+// 	}
+//
+// 	return map;
+// }
 
-	return map;
-}
+// /** Recursively building a map of the different event-creators. */
+// type EventMap<FSS extends unknown[]> = FSS extends [infer F, ...infer FS]
+// 	? F extends EventCreator<infer T, infer P, infer A>
+// 		? Record<T, (...args: A) => P> | EventMap<FS>
+// 		: "Array content must consist of event creators."
+// 	: never;

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -39,10 +39,10 @@ type _EventCreatorWithPayload<
 	? EventCreatorWithPayload<T, Parameters<PA>, P>
 	: never;
 
-/** Basic type for all action creators. */
+/** Basic type for all event creators. */
 interface BaseEventCreator<T extends string, P> {
 	type: T;
-	match: (action: AnyEventObject) => action is StructuredEvent<T, P>;
+	match: (e: AnyEventObject) => e is StructuredEvent<T, P>;
 }
 
 /**
@@ -78,7 +78,7 @@ export interface EventCreatorNoPayload<T extends string>
  * Lastly, the event creator function will have its `toString()` method overridden
  * so that it returns the event type.
  *
- * @param type The action type to use for created actions.
+ * @param type The event type to use for created events.
  * @param prepare A method that takes any number of arguments and returns the event payload.
  */
 export function createEvent<T extends string>(

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -107,3 +107,24 @@ export function createEvent<
 
 	return eventCreator;
 }
+
+/**
+ * Maps event creators to an event object for XState models.
+ * TODO: Fix typings so it is correctly typed in usage. Currently, it throws errors.
+ */
+export function fromEventCreators<
+	Creators extends EventCreator<T, P, A>[],
+	T extends string,
+	P extends object = Empty,
+	A extends unknown[] = []
+>(...creators: Creators) {
+	const map: { [K in T]: EventCreator<K, P, A> } = {} as {
+		[K in T]: EventCreator<K, P, A>;
+	};
+
+	for (const creator of creators) {
+		map[creator.type] = creator;
+	}
+
+	return map;
+}

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,3 +1,4 @@
 export * from "./from_actor";
 export * from "./from_machine";
 export * from "./is_event";
+export * from "./event_creator";


### PR DESCRIPTION
This feature is inspired by `createAction` from @redux-toolkit.

See their documentation for comparison and ideas: https://redux-toolkit.js.org/api/createAction