### PR TITLE
Feat: Add helper to create UI event-handlers from event-creators

### DIFF
--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -66,8 +66,8 @@ describe(createEvent, () => {
 		const ev1 = createEvent("test.first");
 		const ev2 = createEvent("test.second", (body: string) => ({ body }));
 
-		const handleEv1 = ev1.createCallback(receiver);
-		const handleEv2 = ev2.createCallback(receiver);
+		const handleEv1 = ev1.createSendCall(receiver);
+		const handleEv2 = ev2.createSendCall(receiver);
 
 		handleEv1();
 		handleEv2("body");
@@ -78,7 +78,7 @@ describe(createEvent, () => {
 
 		const ev3 = createEvent("test.third");
 		// @ts-expect-error Receiver does not accept "ev3" events
-		ev3.createCallback(receiver);
+		ev3.createSendCall(receiver);
 	});
 
 	it("should be possible to use created events in machine definitions", () => {

--- a/src/utils/event_creator.test.ts
+++ b/src/utils/event_creator.test.ts
@@ -1,4 +1,5 @@
-import { createMachine, interpret } from "xstate";
+import { mock } from "jest-mock-extended";
+import { ActorRef, createMachine, interpret } from "xstate";
 import { createEvent, EventFrom } from "./event_creator";
 
 describe(createEvent, () => {
@@ -51,6 +52,33 @@ describe(createEvent, () => {
 		expect(() => noObject("123")).toThrowError(
 			new TypeError("Prepare must return an object. Was: 123")
 		);
+	});
+
+	it("should provide a helper to construct event-handler callbacks when connecting actors", () => {
+		const receiver =
+			mock<
+				ActorRef<
+					EventFrom<typeof ev1> | EventFrom<typeof ev2>,
+					{ ctxData: string }
+				>
+			>();
+
+		const ev1 = createEvent("test.first");
+		const ev2 = createEvent("test.second", (body: string) => ({ body }));
+
+		const handleEv1 = ev1.createCallback(receiver);
+		const handleEv2 = ev2.createCallback(receiver);
+
+		handleEv1();
+		handleEv2("body");
+
+		expect(receiver.send).toBeCalledTimes(2);
+		expect(receiver.send).nthCalledWith(1, ev1());
+		expect(receiver.send).nthCalledWith(2, ev2("body"));
+
+		const ev3 = createEvent("test.third");
+		// @ts-expect-error Receiver does not accept "ev3" events
+		ev3.createCallback(receiver);
 	});
 
 	it("should be possible to use created events in machine definitions", () => {

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -58,7 +58,7 @@ export interface EventCreator<
 	match(e: AnyEventObject): e is CreatedEvent<T, P>;
 
 	/**
-	 * Creates a callback function that sends events from this {@link EventCreator} to the given actor.
+	 * Creates a function that sends events from this {@link EventCreator} to the given actor when called.
 	 *
 	 * This is intended as a helper when connecting actors to UIs. It avoids the following boilerplate:
 	 *
@@ -68,15 +68,15 @@ export interface EventCreator<
 	 *		data,
 	 * }));
 	 *
-	 * // Creating callbacks in the UI to send events to an actor
+	 * // Creating event-handlers in the UI to send events to an actor
 	 * const actor = useInterpret(...); // Actor that can receive "doSomething" events
 	 *
 	 * // Instead of writing UI event-handlers manually over and over again...
 	 * const handleData = (data: string) => actor.send(doSomething(data));
 	 * // ... it can be writing like this:
-	 * const handleData = doSomething.createCallback(actor); // (data: string) => void;
+	 * const handleData = doSomething.createSendCall(actor); // (data: string) => void;
 	 */
-	createCallback(
+	createSendCall(
 		receiver: ActorRef<CreatedEvent<T, P>, unknown>
 	): (...args: A) => void;
 }
@@ -138,7 +138,7 @@ export function createEvent<
 	eventCreator.match = (e: AnyEventObject): e is CreatedEvent<T, P> =>
 		e.type === type;
 
-	eventCreator.createCallback =
+	eventCreator.createSendCall =
 		(receiver) =>
 		(...args) =>
 			receiver.send(eventCreator(...args));

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -1,4 +1,8 @@
-import type { AnyEventObject, EventFrom as OriginalEventFrom } from "xstate";
+import type {
+	ActorRef,
+	AnyEventObject,
+	EventFrom as OriginalEventFrom,
+} from "xstate";
 
 // This implementation is a port of `createAction` from Redux Toolkit, adapted
 // and simplified to fit into the XState ecosystem.
@@ -46,10 +50,35 @@ export interface EventCreator<
 > {
 	/** Calling this {@link EventCreator} will return a new event object with the configured event `type`. */
 	(...args: A): CreatedEvent<T, P>;
+
 	/** The event type of events that are created with this {@link EventCreator} */
 	type: T;
+
 	/** Type predicate that narrows given events to events created with this {@link EventCreator}. */
-	match: (e: AnyEventObject) => e is CreatedEvent<T, P>;
+	match(e: AnyEventObject): e is CreatedEvent<T, P>;
+
+	/**
+	 * Creates a callback function that sends events from this {@link EventCreator} to the given actor.
+	 *
+	 * This is intended as a helper when connecting actors to UIs. It avoids the following boilerplate:
+	 *
+	 * @example
+	 * // Example event creator
+	 * const doSomething = createEvent("do.make.something", (data: string) => ({
+	 *		data,
+	 * }));
+	 *
+	 * // Creating callbacks in the UI to send events to an actor
+	 * const actor = useInterpret(...); // Actor that can receive "doSomething" events
+	 *
+	 * // Instead of writing UI event-handlers manually over and over again...
+	 * const handleData = (data: string) => actor.send(doSomething(data));
+	 * // ... it can be writing like this:
+	 * const handleData = doSomething.createCallback(actor); // (data: string) => void;
+	 */
+	createCallback(
+		receiver: ActorRef<CreatedEvent<T, P>, unknown>
+	): (...args: A) => void;
 }
 
 /**
@@ -57,6 +86,10 @@ export interface EventCreator<
  * for constructing new events of that type.
  * An additional `type` property is attached to the returned {@link EventCreator}
  * function which equals the provided type and can be used to avoid "magic strings".
+ *
+ * To connect your UI with your actors, you can use the `createCallback` helper to
+ * avoid boilerplate when writing event handlers. See the TSDoc for `createCallback`
+ * on the {@link EventCreator} interface.
  *
  * Furthermore, a `match` type predicate is attached to the {@link EventCreator},
  * which narrows given events to events with the same type.
@@ -104,6 +137,11 @@ export function createEvent<
 	eventCreator.type = type;
 	eventCreator.match = (e: AnyEventObject): e is CreatedEvent<T, P> =>
 		e.type === type;
+
+	eventCreator.createCallback =
+		(receiver) =>
+		(...args) =>
+			receiver.send(eventCreator(...args));
 
 	return eventCreator;
 }

--- a/src/utils/event_creator.ts
+++ b/src/utils/event_creator.ts
@@ -87,8 +87,8 @@ export interface EventCreator<
  * An additional `type` property is attached to the returned {@link EventCreator}
  * function which equals the provided type and can be used to avoid "magic strings".
  *
- * To connect your UI with your actors, you can use the `createCallback` helper to
- * avoid boilerplate when writing event handlers. See the TSDoc for `createCallback`
+ * To connect your UI with your actors, you can use the `createSendCall` helper to
+ * avoid boilerplate when writing event handlers. See the TSDoc for `createSendCall`
  * on the {@link EventCreator} interface.
  *
  * Furthermore, a `match` type predicate is attached to the {@link EventCreator},


### PR DESCRIPTION
This helps to avoid boilerplate when connecting actors to UIs:

```typescript
// Example event creator
const doSomething = createEvent("do.make.something", (data: string) => ({
    data,
}));

// Creating callbacks in the UI to send events to an actor
const actor = useInterpret(...); // Actor that can receive "doSomething" events

// Instead of writing UI event-handlers manually over and over again...
const handleData = (data: string) => actor.send(doSomething(data));
// ... it can be writing like this:
const handleData = doSomething.createSendCall(actor); // (data: string) => void;
```